### PR TITLE
Add processing for the NGINX Config POST endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Thumbs.db
 *.log
 
 _build/
+cover.*

--- a/assets/sample-nginx-config.1
+++ b/assets/sample-nginx-config.1
@@ -1,0 +1,35 @@
+http {
+    # Define the upstream servers for backend1
+    upstream backend1 {
+        server backend1-server1.example.com;
+        server backend1-server2.example.com;
+        # Additional load balancing configuration (if needed) goes here
+    }
+
+    # Define the upstream servers for backend2
+    upstream backend2 {
+        server backend2-server1.example.com;
+        server backend2-server2.example.com;
+        # Additional load balancing configuration (if needed) goes here
+    }
+
+    server {
+        listen 80;
+
+        # Example location block for backend1
+        location /backend1/ {
+            proxy_pass http://backend1;
+            # Additional reverse proxy configuration (if needed) goes here
+        }
+
+        # Example location block for backend2
+        location /backend2/ {
+            proxy_pass http://backend2;
+            # Additional reverse proxy configuration (if needed) goes here
+        }
+
+        # Other server configuration (like error pages) goes here
+    }
+}
+
+# Additional global NGINX configuration (like events) goes here

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,57 @@
+# Design
+
+## Overview
+
+### Architecture
+
+```mermaid
+```
+
+### Components
+
+The following components are used in the system:
+
+- **Server**: Standard HTTP server, handles incoming requests and passes them to the handler.
+- **HttpHandler**: Handles incoming requests, passes them to the request processor and returns the response.
+- **RequestProcessor**: Processes incoming requests, returns the response.
+- **Updater**: Updates the NGINX config.
+
+#### Server
+
+The server is a standard HTTP server, which handles incoming requests and passes them to the handler. Routes
+are defined by handler implementations; the list of Routes is defined in the `handler.go` file.
+
+#### HttpHandler
+
+The HTTP handler handles incoming requests by creates a concrete `configs.Interface` instance and passing it to the update processor.
+An HTTP 202 Created response that includes a Location header containing the URL of the created resource and JSON body containing the
+UpdateEvent detail is returned.
+
+Handler implementation defines a route. The planned routes are:
+
+- `/nginx/config/raw/{name}`: Create / Delete raw NGINX config
+- `/nginx/config/upstream/{name}`: Create / Delete an upstream config
+- `/nginx/config/server/{name}`: Create / Delete a server config
+
+Note: only POST and DELETE methods are supported.
+
+#### ConfigUpdateProcessor
+
+Given a concrete `configs.Interface` instance, the update processor creates a new `UpdateEvent` and passes it to the updater via channel.
+
+#### UpdateEvent
+
+The `UpdateEvent` contains the information needed to build the NGINX config. It also maintains a log of events that occur during the
+update process.
+
+An `UpdateEvent` is initialized in the `Accepted` state. Each step along the way, the `UpdateEvent` is updated with the current state.
+
+If, at any step, the update fails, the `UpdateEvent` is updated with the current state and the `Error` field is set to the error message.
+
+#### UpdateProcessor
+
+- Maintains a buffered channel of `UpdateEvent` instances
+- Updates the NGINX config by saving a file in the NGINX config directory
+- Filename is provided as the final route segment
+- Once file is written, invoke `nginx -t` to test the config; if successful, invoke `nginx -s reload` to reload the config.
+ 

--- a/go.mod
+++ b/go.mod
@@ -6,19 +6,15 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/sirupsen/logrus v1.9.3-0.20230531171720-7165f5e779a5
 )
+
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/google/uuid v1.5.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
-)
-
-replace (
-	github.com/nginxinc/kubernetes-nginx-ingress/internal/config => ./internal/config
-	github.com/nginxinc/kubernetes-nginx-ingress/internal/translation => ./internal/translation
-	github.com/nginxinc/kubernetes-nginx-ingress/internal/translation/nginxplus => ./internal/translation/nginxplus
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
+github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	DefaultUpdateChannelSize    = 100
 	DefaultHost                 = "0.0.0.0"
 	DefaultPort                 = "8293"
 	DefaultLogLevel             = logrus.InfoLevel
@@ -20,9 +21,10 @@ const (
 )
 
 type Settings struct {
-	Host     string
-	Port     string
-	LogLevel logrus.Level
+	UpdateChannelSize int
+	Host              string
+	Port              string
+	LogLevel          logrus.Level
 }
 
 func NewSettings() (*Settings, error) {
@@ -38,7 +40,7 @@ func NewSettings() (*Settings, error) {
 
 	logLevel := getLogLevel()
 
-	config := &Settings{host, port, logLevel}
+	config := &Settings{DefaultUpdateChannelSize, host, port, logLevel}
 
 	return config, nil
 }

--- a/internal/handlers/context.go
+++ b/internal/handlers/context.go
@@ -1,0 +1,23 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package handlers
+
+import (
+	"ciroque/go-http-server/internal/processing"
+	"github.com/sirupsen/logrus"
+)
+
+type Context struct {
+	Logger    *logrus.Entry
+	Processor *processing.ConfigUpdateProcessor
+}
+
+func NewContext(logger *logrus.Entry, processor *processing.ConfigUpdateProcessor) *Context {
+	return &Context{
+		Logger:    logger,
+		Processor: processor,
+	}
+}

--- a/internal/handlers/raw_config_handler.go
+++ b/internal/handlers/raw_config_handler.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package handlers
+
+import (
+	"ciroque/go-http-server/internal/metrics"
+	"ciroque/go-http-server/internal/nginx/configs"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"io"
+	"net/http"
+)
+
+type RawConfigHandler struct {
+	Context          *Context
+	RequestCount     *prometheus.CounterVec
+	RequestDurations *prometheus.HistogramVec
+}
+
+func NewRawConfigHandler(context *Context) *RawConfigHandler {
+	return &RawConfigHandler{Context: context}
+}
+
+func (handler *RawConfigHandler) Cleanup() {
+	handler.Context.Logger.Info("RawConfigHandler::Cleanup")
+	prometheus.Unregister(handler.RequestCount)
+	prometheus.Unregister(handler.RequestDurations)
+}
+
+func (handler *RawConfigHandler) BuildHandler() (http.Handler, error) {
+	handler.configureMetrics()
+	err := handler.registerMetrics()
+	if err != nil {
+		return nil, err
+	}
+
+	h := promhttp.InstrumentHandlerCounter(
+		handler.RequestCount,
+		promhttp.InstrumentHandlerDuration(
+			handler.RequestDurations,
+			http.HandlerFunc(handler.handler)))
+
+	return h, nil
+}
+
+func (handler *RawConfigHandler) Route() string {
+	return "/nginx/config"
+}
+
+func (handler *RawConfigHandler) handler(writer http.ResponseWriter, request *http.Request) {
+	responseStatusCode := http.StatusAccepted
+
+	if request.Method != http.MethodPost {
+		writer.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		WriteErrorResponse(writer, "Error reading request body", http.StatusInternalServerError, handler.Context.Logger)
+		return
+	}
+
+	if len(body) == 0 {
+		WriteErrorResponse(writer, "An NGINX configuration was not found in the request", http.StatusBadRequest, handler.Context.Logger)
+		return
+	}
+
+	rawConfig, err := configs.NewRawConfig(body).GetConfig()
+	if err != nil {
+		WriteErrorResponse(writer, "Error parsing the NGINX configuration", http.StatusBadRequest, handler.Context.Logger)
+		return
+	}
+
+	configUpdateEvent, err := handler.Context.Processor.QueueConfigUpdate(rawConfig)
+	if err != nil {
+		handler.Context.Logger.Warnf("Error queuing the NGINX configuration, %#v", err)
+		responseStatusCode = http.StatusConflict
+	}
+
+	writer.Header().Add("Location", configUpdateEvent.Location)
+
+	// Close the request body to release resources
+	defer request.Body.Close()
+
+	WriteUpdateEvent(writer, configUpdateEvent, responseStatusCode, handler.Context.Logger)
+}
+
+func (handler *RawConfigHandler) configureMetrics() {
+	handler.RequestCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.RootSubsystem,
+			Name:      "nginx_config_post_request_count",
+			Help:      "The number of requests served by the nginx config post handler",
+		}, []string{"code", "method"})
+
+	handler.RequestDurations = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.RootSubsystem,
+			Name:      "nginx_config_post_request_durations",
+			Help:      "The duration of requests served by the nginx config post handler",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"code", "method"})
+}
+
+func (handler *RawConfigHandler) registerMetrics() error {
+	err := prometheus.Register(handler.RequestCount)
+	if err != nil {
+		return err
+	}
+
+	err = prometheus.Register(handler.RequestDurations)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/handlers/root_path_handler.go
+++ b/internal/handlers/root_path_handler.go
@@ -12,23 +12,23 @@ import (
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/sirupsen/logrus"
 	"net/http"
 )
 
 type RootPathHandler struct {
-	Logger                   *logrus.Entry
-	RootPathRequestCount     *prometheus.CounterVec
-	RootPathRequestDurations *prometheus.HistogramVec
+	Context          *Context
+	RequestCount     *prometheus.CounterVec
+	RequestDurations *prometheus.HistogramVec
 }
 
-func NewRootPathHandler(logger *logrus.Entry) *RootPathHandler {
-	return &RootPathHandler{Logger: logger}
+func NewRootPathHandler(context *Context) *RootPathHandler {
+	return &RootPathHandler{context, nil, nil}
 }
 
 func (handler *RootPathHandler) Cleanup() {
-	prometheus.Unregister(handler.RootPathRequestCount)
-	prometheus.Unregister(handler.RootPathRequestDurations)
+	handler.Context.Logger.Info("RootPathHandler::Cleanup")
+	prometheus.Unregister(handler.RequestCount)
+	prometheus.Unregister(handler.RequestDurations)
 }
 
 func (handler *RootPathHandler) BuildHandler() (http.Handler, error) {
@@ -39,9 +39,9 @@ func (handler *RootPathHandler) BuildHandler() (http.Handler, error) {
 	}
 
 	h := promhttp.InstrumentHandlerCounter(
-		handler.RootPathRequestCount,
+		handler.RequestCount,
 		promhttp.InstrumentHandlerDuration(
-			handler.RootPathRequestDurations,
+			handler.RequestDurations,
 			http.HandlerFunc(handler.handler)))
 
 	return h, nil
@@ -52,47 +52,49 @@ func (handler *RootPathHandler) Route() string {
 }
 
 func (handler *RootPathHandler) handler(writer http.ResponseWriter, request *http.Request) {
-	handler.Logger.Debugf("Server::ServeRootPath: %#v", request)
-	response := responses.NewRootPathResponse("200 OK")
+	handler.Context.Logger.Debugf("Server::ServeRootPath: %#v", request)
+	response := responses.NewJsonBodyResponse("200 OK")
 
 	bytes, err := json.Marshal(&response)
 	if err != nil {
-		handler.Logger.Warnf("Error responding to request %#v", err)
+		handler.Context.Logger.Warnf("Error responding to request %#v", err)
 	}
 
 	writer.Header().Add("Content-Type", "application/json")
 	_, err = fmt.Fprintf(writer, "%s", bytes)
 	if err != nil {
-		handler.Logger.Warnf("Error responding to request %#v", err)
+		handler.Context.Logger.Warnf("Error responding to request %#v", err)
 	}
 
-	handler.Logger.Debugf("Server::ServeRootPath: %#v", response)
+	handler.Context.Logger.Debugf("Server::ServeRootPath: %#v", response)
 }
 
 func (handler *RootPathHandler) configureMetrics() {
-	handler.RootPathRequestCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: metrics.RootSubsystem,
-		Name:      "root_path_request_count",
-		Help:      "The number of requests to the root path",
-	}, []string{"code", "method"})
+	handler.RequestCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.RootSubsystem,
+			Name:      "root_path_request_count",
+			Help:      "The number of requests to the root path",
+		}, []string{"code", "method"})
 
-	handler.RootPathRequestDurations = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: metrics.RootSubsystem,
-		Name:      "root_path_request_duration",
-		Help:      "Tracks how long it takes to retrieve the root path",
-		Buckets:   prometheus.DefBuckets,
-	}, []string{"code", "method"})
+	handler.RequestDurations = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.RootSubsystem,
+			Name:      "root_path_request_duration",
+			Help:      "Tracks how long it takes to retrieve the root path",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"code", "method"})
 }
 
 func (handler *RootPathHandler) registerMetrics() error {
-	err := prometheus.Register(handler.RootPathRequestCount)
+	err := prometheus.Register(handler.RequestCount)
 	if err != nil {
 		return err
 	}
 
-	err = prometheus.Register(handler.RootPathRequestDurations)
+	err = prometheus.Register(handler.RequestDurations)
 	if err != nil {
 		return err
 	}

--- a/internal/handlers/status_handler.go
+++ b/internal/handlers/status_handler.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package handlers
+
+import (
+	"ciroque/go-http-server/internal/metrics"
+	"errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type StatusHandler struct {
+	Context          *Context
+	RequestCount     *prometheus.CounterVec
+	RequestDurations *prometheus.HistogramVec
+}
+
+func NewStatusHandler(context *Context) *StatusHandler {
+	return &StatusHandler{Context: context}
+}
+
+func (handler *StatusHandler) Cleanup() {
+	handler.Context.Logger.Info("RawConfigHandler::Cleanup")
+	prometheus.Unregister(handler.RequestCount)
+	prometheus.Unregister(handler.RequestDurations)
+}
+
+func (handler *StatusHandler) BuildHandler() (http.Handler, error) {
+	handler.configureMetrics()
+	err := handler.registerMetrics()
+	if err != nil {
+		return nil, err
+	}
+
+	h := promhttp.InstrumentHandlerCounter(
+		handler.RequestCount,
+		promhttp.InstrumentHandlerDuration(
+			handler.RequestDurations,
+			http.HandlerFunc(handler.handler)))
+
+	return h, nil
+}
+
+func (handler *StatusHandler) Route() string {
+	return "/nginx/config/status/"
+}
+
+func (handler *StatusHandler) handler(writer http.ResponseWriter, request *http.Request) {
+	handler.Context.Logger.Debugf("StatusHandler::handle %#v", request)
+
+	eventId, err := handler.getEventIdFromRequest(request)
+	if err != nil {
+		WriteErrorResponse(writer, err.Error(), http.StatusBadRequest, handler.Context.Logger)
+		return
+	}
+
+	updateEvent, err := handler.Context.Processor.LookUpEvent(eventId)
+	if err != nil {
+		WriteErrorResponse(writer, err.Error(), http.StatusNotFound, handler.Context.Logger)
+		return
+	}
+
+	WriteUpdateEvent(writer, updateEvent, http.StatusOK, handler.Context.Logger)
+}
+
+func (handler *StatusHandler) configureMetrics() {
+	handler.RequestCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.RootSubsystem,
+			Name:      "status_request_count",
+			Help:      "The number of requests served by the status handler",
+		}, []string{"code", "method"})
+
+	handler.RequestDurations = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.RootSubsystem,
+			Name:      "status_request_durations",
+			Help:      "The duration of requests served by the status handler",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"code", "method"})
+}
+
+func (handler *StatusHandler) registerMetrics() error {
+	err := prometheus.Register(handler.RequestCount)
+	if err != nil {
+		return err
+	}
+
+	err = prometheus.Register(handler.RequestDurations)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (handler *StatusHandler) getEventIdFromRequest(request *http.Request) (uint64, error) {
+	segments := strings.Split(request.URL.Path, "/")
+	if len(segments) < 5 {
+		return 0, errors.New("invalid path")
+	}
+
+	segment := segments[4]
+	handler.Context.Logger.Debugf("StatusHandler::getEventIdFromRequest: %#v", segment)
+
+	eventId, err := strconv.ParseUint(segment, 10, 64)
+	if err != nil {
+		return 0, errors.New("invalid id")
+	}
+
+	return eventId, nil
+}

--- a/internal/http-server/server.go
+++ b/internal/http-server/server.go
@@ -46,7 +46,10 @@ func (server *Server) Run(stopCh <-chan struct{}) {
 		if err != nil {
 			server.Logger.Fatalf("Error building handler %#v", err)
 		}
+
 		mux.Handle(route.Route(), handler)
+
+		defer route.Cleanup()
 	}
 
 	address := fmt.Sprintf("%s:%s", server.Settings.Host, server.Settings.Port)

--- a/internal/nginx/configs/raw_config.go
+++ b/internal/nginx/configs/raw_config.go
@@ -1,0 +1,20 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package configs
+
+type RawConfig struct {
+	rawConfig []byte
+}
+
+func NewRawConfig(rawConfig []byte) *RawConfig {
+	return &RawConfig{
+		rawConfig: rawConfig,
+	}
+}
+
+func (config *RawConfig) GetConfig() (string, error) {
+	return string(config.rawConfig), nil
+}

--- a/internal/nginx/configs/raw_config_test.go
+++ b/internal/nginx/configs/raw_config_test.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package configs
+
+import "testing"
+
+func TestNewRawConfig(t *testing.T) {
+	configValue := []byte("test config")
+
+	config := NewRawConfig(configValue)
+	if config == nil {
+		t.Error("Expected a non-nil value")
+	}
+}
+
+func TestRawConfig_GetConfig(t *testing.T) {
+	configValue := []byte("test config")
+	config := NewRawConfig(configValue)
+	if config == nil {
+		t.Error("Expected a non-nil value")
+	}
+	configValueReturned, err := config.GetConfig()
+	if err != nil {
+		t.Error("Expected a nil error")
+	}
+
+	if configValueReturned != string(configValue) {
+		t.Errorf("Expected %s, got %s", configValue, configValueReturned)
+	}
+}

--- a/internal/nginx/configs/server_config.go
+++ b/internal/nginx/configs/server_config.go
@@ -1,0 +1,6 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package configs

--- a/internal/nginx/configs/upstream_config.go
+++ b/internal/nginx/configs/upstream_config.go
@@ -1,0 +1,6 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package configs

--- a/internal/nginx/file/context.go
+++ b/internal/nginx/file/context.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package file
+
+import (
+	"ciroque/go-http-server/internal/processing"
+	"context"
+	"github.com/sirupsen/logrus"
+)
+
+type ManagerContext struct {
+	Context       context.Context
+	Logger        *logrus.Entry
+	UpdateChannel chan *processing.ConfigUpdateEvent
+}
+
+func NewManagerContext(context context.Context, logger *logrus.Entry, updateChannel chan *processing.ConfigUpdateEvent) *ManagerContext {
+	return &ManagerContext{
+		Context:       context,
+		Logger:        logger,
+		UpdateChannel: updateChannel,
+	}
+}

--- a/internal/nginx/file/manager.go
+++ b/internal/nginx/file/manager.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package file
+
+import (
+	"ciroque/go-http-server/internal/config"
+	"ciroque/go-http-server/internal/processing"
+)
+
+type ConfigFileManager struct {
+	settings *config.Settings
+	context  *ManagerContext
+}
+
+func NewConfigFileManager(settings *config.Settings, context *ManagerContext) *ConfigFileManager {
+	return &ConfigFileManager{
+		settings: settings,
+		context:  context,
+	}
+}
+
+func (manager *ConfigFileManager) Start() {
+	for {
+		select {
+		case event, open := <-manager.context.UpdateChannel:
+			if !open {
+				manager.context.Logger.Info("Update channel closed")
+				return
+			}
+
+			err := processUpdateEvent(event)
+			manager.context.Logger.Infof("Processed event: %v\n", event)
+			if err != nil {
+				manager.context.Logger.Errorf("Error processing event: %v\n", err)
+			}
+
+			select {
+			case <-manager.context.Context.Done():
+				manager.context.Logger.Info("ManagerContext done")
+				return
+			}
+
+		case <-manager.context.Context.Done():
+			manager.context.Logger.Info("ManagerContext done")
+			return
+		}
+	}
+}
+
+func processUpdateEvent(event *processing.ConfigUpdateEvent) error {
+
+	if event.EventID/3 == 0 {
+		event.SetError("This is an error")
+		return nil
+	}
+
+	event.SetState(processing.Started)
+
+	event.SetState(processing.Validating)
+
+	event.SetState(processing.Validated)
+
+	event.SetState(processing.Pending)
+
+	event.SetState(processing.Applied)
+
+	return nil
+}

--- a/internal/nginx/file/manager_test.go
+++ b/internal/nginx/file/manager_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package file
+
+import (
+	"ciroque/go-http-server/internal/config"
+	"ciroque/go-http-server/internal/processing"
+	context2 "context"
+	"github.com/sirupsen/logrus"
+	"testing"
+	"time"
+)
+
+func TestNewUpdater(t *testing.T) {
+	context := context2.Context(context2.Background())
+	updateChannel := make(chan *processing.ConfigUpdateEvent)
+
+	logger := logrus.New()
+	loggerEntry := logrus.NewEntry(logger)
+
+	updaterContext := NewManagerContext(context, loggerEntry, updateChannel)
+
+	settings, _ := config.NewSettings()
+
+	updater := NewConfigFileManager(settings, updaterContext)
+
+	if updater == nil {
+		t.Error("Expected updater to not be nil")
+	}
+}
+
+func TestUpdater_Start(t *testing.T) {
+	context := context2.Context(context2.Background())
+	updateChannel := make(chan *processing.ConfigUpdateEvent)
+
+	logger := logrus.New()
+	loggerEntry := logrus.NewEntry(logger)
+
+	updaterContext := NewManagerContext(context, loggerEntry, updateChannel)
+
+	settings, _ := config.NewSettings()
+
+	updater := NewConfigFileManager(settings, updaterContext)
+
+	go updater.Start()
+
+	updateEvent := processing.NewConfigUpdateEvent("Config Body")
+
+	updateChannel <- updateEvent
+}
+
+func TestUpdater_StartClosedChannel(t *testing.T) {
+	context := context2.Context(context2.Background())
+	updateChannel := make(chan *processing.ConfigUpdateEvent)
+
+	logger := logrus.New()
+	loggerEntry := logrus.NewEntry(logger)
+
+	updaterContext := NewManagerContext(context, loggerEntry, updateChannel)
+
+	settings, _ := config.NewSettings()
+
+	updater := NewConfigFileManager(settings, updaterContext)
+
+	go updater.Start()
+
+	close(updateChannel)
+}
+
+func TestUpdater_StartContextDone(t *testing.T) {
+	context, cancel := context2.WithCancel(context2.Background())
+	updateChannel := make(chan *processing.ConfigUpdateEvent)
+
+	logger := logrus.New()
+	loggerEntry := logrus.NewEntry(logger)
+
+	updaterContext := NewManagerContext(context, loggerEntry, updateChannel)
+
+	settings, _ := config.NewSettings()
+
+	updater := NewConfigFileManager(settings, updaterContext)
+
+	go updater.Start()
+
+	cancel()
+}
+
+func TestUpdater_StartContextDoneAfterWork(t *testing.T) {
+	context, cancel := context2.WithCancel(context2.Background())
+	updateChannel := make(chan *processing.ConfigUpdateEvent)
+
+	logger := logrus.New()
+	loggerEntry := logrus.NewEntry(logger)
+
+	updaterContext := NewManagerContext(context, loggerEntry, updateChannel)
+
+	settings, _ := config.NewSettings()
+
+	updater := NewConfigFileManager(settings, updaterContext)
+
+	go updater.Start()
+
+	updateEvent := processing.NewConfigUpdateEvent("Config Body")
+
+	updateChannel <- updateEvent
+
+	cancel()
+
+	time.Sleep(2 * time.Second)
+}

--- a/internal/processing/config_update_event.go
+++ b/internal/processing/config_update_event.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package processing
+
+import (
+	json2 "encoding/json"
+	"errors"
+	"fmt"
+	"github.com/cespare/xxhash/v2"
+	"time"
+)
+
+type EventState int
+
+const (
+	Failed EventState = iota
+	Accepted
+	Started
+	Validating
+	Validated
+	Pending
+	Applied
+)
+
+func (s EventState) String() string {
+	return [...]string{"Failed", "Accepted", "Started", "Validating", "Validated", "Pending", "Applied"}[s]
+}
+
+func (s EventState) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + s.String() + `"`), nil
+}
+
+type ConfigUpdateEvent struct {
+	ConfigBody string                   `json:"configuration"`
+	EventState EventState               `json:"state"`
+	EventLog   map[time.Time]EventState `json:"log"`
+	Error      string                   `json:"error"`
+	EventID    uint64                   `json:"id"`
+	Location   string                   `json:"location"`
+}
+
+// NewConfigUpdateEvent creates a new ConfigUpdateEvent
+//
+// [xxhash](https://pkg.go.dev/github.com/cespare/xxhash) is used to generate the hash.
+//
+// This choice is due to its speed and low collision rate, and the fact that a strong cryptographic hash is not required.
+func NewConfigUpdateEvent(configBody string) *ConfigUpdateEvent {
+	eventId := xxhash.Sum64String(configBody)
+	return &ConfigUpdateEvent{
+		ConfigBody: configBody,
+		EventState: Accepted,
+		EventLog:   map[time.Time]EventState{time.Now(): Accepted},
+		EventID:    eventId,
+		Location:   fmt.Sprintf("/nginx/config/status/%d", eventId),
+	}
+}
+
+func (e *ConfigUpdateEvent) SetState(state EventState) error {
+	if state == Failed {
+		return errors.New("EventState cannot be set to `Failed` directly; use SetError() instead")
+	}
+
+	e.EventState = state
+	e.EventLog[time.Now()] = state
+
+	return nil
+}
+
+func (e *ConfigUpdateEvent) SetError(err string) {
+	e.EventState = Failed
+	e.Error = err
+	e.EventLog[time.Now()] = Failed
+}
+
+func (e *ConfigUpdateEvent) Json() ([]byte, error) {
+	return json2.Marshal(e)
+}

--- a/internal/processing/config_update_event_test.go
+++ b/internal/processing/config_update_event_test.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package processing
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewConfigUpdateEvent(t *testing.T) {
+	configurationBody := "Text NGINX Configuration"
+	event := NewConfigUpdateEvent(configurationBody)
+
+	if event == nil {
+		t.Errorf("Expected event to not be nil")
+	}
+
+	if event.ConfigBody != configurationBody {
+		t.Errorf("Expected event.ConfigurationBody to be '%s', but was '%s'", configurationBody, event.ConfigBody)
+	}
+
+	if event.EventState != Accepted {
+		t.Errorf("Expected event.EventState to be 'Accepted', but was '%d'", event.EventState)
+	}
+
+	if event.Error != "" {
+		t.Errorf("Expected event.Error to be nil, but was '%s'", event.Error)
+	}
+}
+
+func TestConfigUpdateEvent_SetState(t *testing.T) {
+	configurationBody := "Text NGINX Configuration"
+	event := NewConfigUpdateEvent(configurationBody)
+
+	err := event.SetState(Started)
+	if err != nil {
+		t.Errorf("Expected event.SetState() to not return an error, but got '%s'", err)
+	}
+
+	if event.EventState != Started {
+		t.Errorf("Expected event.EventState to be 'Started', but was '%d'", event.EventState)
+	}
+
+	if event.Error != "" {
+		t.Errorf("Expected event.Error to be nil, but was '%s'", event.Error)
+	}
+}
+
+func TestConfigUpdateEvent_SetError(t *testing.T) {
+	errorMessage := "Something went horribly, horribly wrong"
+	configurationBody := "Text NGINX Configuration"
+	event := NewConfigUpdateEvent(configurationBody)
+
+	event.SetError(errorMessage)
+
+	if event.EventState != Failed {
+		t.Errorf("Expected event.EventState to be 'Failed', but was '%d'", event.EventState)
+	}
+
+	if event.Error != "" && event.Error != errorMessage {
+		t.Errorf("Expected event.Error to be '%s', but was '%s'", errorMessage, event.Error)
+	}
+}
+
+func TestConfigUpdateEvent_SetErrorFail(t *testing.T) {
+	configurationBody := "Test NGINX Configuration"
+	event := NewConfigUpdateEvent(configurationBody)
+
+	err := event.SetState(Failed)
+	if err == nil {
+		t.Errorf("Expected event.SetState() to return an error, but got nil")
+	}
+
+	if event.EventState != Accepted {
+		t.Errorf("Expected event.EventState to be 'Accepted', but was '%d'", event.EventState)
+	}
+
+	if event.Error != "" {
+		t.Errorf("Expected event.Error to be nil, but was '%s'", event.Error)
+	}
+
+	if err != nil && err.Error() != "EventState cannot be set to `Failed` directly; use SetError() instead" {
+		t.Errorf("Expected event.SetState() to return an error, but got '%s'", err)
+	}
+}
+
+func TestEventState_MarshalJSON(t *testing.T) {
+	state := Accepted
+	json, err := state.MarshalJSON()
+	if err != nil {
+		t.Errorf("Expected MarshalJSON() to not return an error, but got '%s'", err)
+	}
+
+	if string(json) != `"Accepted"` {
+		t.Errorf("Expected MarshalJSON() to return 'Accepted', but got '%s'", string(json))
+	}
+}
+
+func TestEventState_String(t *testing.T) {
+	state := Accepted
+	if state.String() != "Accepted" {
+		t.Errorf("Expected String() to return 'Accepted', but got '%s'", state.String())
+	}
+}
+
+func TestConfigUpdateEvent_Json(t *testing.T) {
+	configurationBody := "Text NGINX Configuration"
+	event := NewConfigUpdateEvent(configurationBody)
+
+	json, err := event.Json()
+	if err != nil {
+		t.Errorf("Expected Json() to not return an error, but got '%s'", err)
+	}
+
+	if !strings.Contains(string(json), `Text NGINX Configuration`) && strings.Contains(string(json), `Accepted`) {
+		t.Errorf("Expected Json() to return '{\"configuration\": \"Text NGINX Configuration\", \"state\": \"Accepted\"}', but got '%s'", string(json))
+	}
+}

--- a/internal/processing/config_update_processor.go
+++ b/internal/processing/config_update_processor.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package processing
+
+import (
+	"errors"
+	"fmt"
+)
+
+type ConfigUpdateProcessor struct {
+	events        map[uint64]*ConfigUpdateEvent
+	updateChannel chan *ConfigUpdateEvent
+}
+
+func NewConfigUpdateProcessor(updateChannel chan *ConfigUpdateEvent) *ConfigUpdateProcessor {
+	return &ConfigUpdateProcessor{
+		events:        make(map[uint64]*ConfigUpdateEvent),
+		updateChannel: updateChannel,
+	}
+}
+
+// QueueConfigUpdate adds a ConfigUpdateEvent to the processor's event map.
+func (c *ConfigUpdateProcessor) QueueConfigUpdate(config string) (*ConfigUpdateEvent, error) {
+	configUpdate := NewConfigUpdateEvent(config)
+
+	if _, found := c.events[configUpdate.EventID]; found {
+		errorMessage := fmt.Sprintf("event with key '%d' already exists", configUpdate.EventID)
+		configUpdate.SetError(errorMessage)
+		return configUpdate, errors.New(errorMessage)
+	}
+
+	c.events[configUpdate.EventID] = configUpdate
+
+	c.updateChannel <- configUpdate
+
+	return configUpdate, nil
+}
+
+func (c *ConfigUpdateProcessor) LookUpEvent(eventID uint64) (*ConfigUpdateEvent, error) {
+	event, found := c.events[eventID]
+	if !found {
+		return nil, errors.New(fmt.Sprintf("event with id '%d' not found", eventID))
+	}
+	return event, nil
+}

--- a/internal/processing/config_update_processor_test.go
+++ b/internal/processing/config_update_processor_test.go
@@ -1,0 +1,132 @@
+/*
+ * Copyright Steve Wagner. All rights reserved.
+ * Use of this source code is governed by the Apache License that can be found in the LICENSE file.
+ */
+
+package processing
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TODO: Provide a channel that works with the test
+func TestConfigUpdateProcessor_QueueConfigUpdate(t *testing.T) {
+	configBody := "Sample NGINX Configuration"
+	updateChannel := make(chan *ConfigUpdateEvent)
+
+	go func() {
+		for {
+			select {
+			case updateEvent := <-updateChannel:
+				fmt.Printf("updateEvent: %v\n", updateEvent)
+			}
+		}
+	}()
+
+	processor := NewConfigUpdateProcessor(updateChannel)
+	configUpdateEvent, err := processor.QueueConfigUpdate(configBody)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if configUpdateEvent.EventID == 0 {
+		t.Errorf("expected eventID to be initialized")
+	}
+}
+
+func TestConfigUpdateProcessor_QueueConfigUpdate_Duplicate(t *testing.T) {
+	configBody := "Sample NGINX Configuration"
+	updateChannel := make(chan *ConfigUpdateEvent)
+
+	go func() {
+		for {
+			select {
+			case updateEvent := <-updateChannel:
+				fmt.Printf("updateEvent: %v\n", updateEvent)
+			}
+		}
+	}()
+
+	processor := NewConfigUpdateProcessor(updateChannel)
+
+	configUpdateEvent, err := processor.QueueConfigUpdate(configBody)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if configUpdateEvent.EventID == 0 {
+		t.Errorf("expected eventID to be intialized")
+	}
+
+	duplicateUpdateEvent, err := processor.QueueConfigUpdate(configBody)
+	if err == nil {
+		t.Errorf("expected error, got none")
+	}
+
+	// The found id is returned
+	if duplicateUpdateEvent.EventID != configUpdateEvent.EventID {
+		t.Errorf("expected nextEventID to be uninitialized, got %d", duplicateUpdateEvent.EventID)
+	}
+
+	if err.Error() != fmt.Sprintf("event with key '%d' already exists", configUpdateEvent.EventID) {
+		t.Errorf("expected error to be 'event with key '%d' already exists', got %s", configUpdateEvent.EventID, err.Error())
+	}
+}
+
+func TestConfigUpdateProcessor_LookUpEvent(t *testing.T) {
+	configBody := "Sample NGINX Configuration"
+	updateChannel := make(chan *ConfigUpdateEvent)
+
+	go func() {
+		for {
+			select {
+			case updateEvent := <-updateChannel:
+				fmt.Printf("updateEvent: %v\n", updateEvent)
+			}
+		}
+	}()
+
+	processor := NewConfigUpdateProcessor(updateChannel)
+
+	updateEvent, err := processor.QueueConfigUpdate(configBody)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if updateEvent.EventID == 0 {
+		t.Errorf("expected eventID to be intialized")
+	}
+
+	event, err := processor.LookUpEvent(updateEvent.EventID)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if event == nil {
+		t.Errorf("expected event to be non-nil")
+	}
+
+	if event.ConfigBody != string(configBody) {
+		t.Errorf("expected event.ConfigurationBody to be 'test', got %s", event.ConfigBody)
+	}
+}
+
+func TestConfigUpdateProcessor_LookUpEvent_NotFound(t *testing.T) {
+	eventId := uint64(1)
+	updateChannel := make(chan *ConfigUpdateEvent)
+	processor := NewConfigUpdateProcessor(updateChannel)
+
+	event, err := processor.LookUpEvent(eventId)
+	if err == nil {
+		t.Errorf("expected error, got none")
+	}
+
+	if event != nil {
+		t.Errorf("expected event to be nil")
+	}
+
+	if err.Error() != fmt.Sprintf("event with id '%d' not found", eventId) {
+		t.Errorf("expected error to be 'event with id '%d' not found', got %s", eventId, err.Error())
+	}
+}

--- a/internal/responses/json_body_response.go
+++ b/internal/responses/json_body_response.go
@@ -5,10 +5,10 @@
 
 package responses
 
-type RootPathResponse struct {
+type JsonBodyResponse struct {
 	Body string `json:"text"`
 }
 
-func NewRootPathResponse(body string) RootPathResponse {
-	return RootPathResponse{Body: body}
+func NewJsonBodyResponse(json string) JsonBodyResponse {
+	return JsonBodyResponse{Body: json}
 }

--- a/internal/responses/json_body_response_test.go
+++ b/internal/responses/json_body_response_test.go
@@ -8,7 +8,7 @@ package responses
 import "testing"
 
 func TestRootPathResponse(t *testing.T) {
-	response := NewRootPathResponse("Hello, World!")
+	response := NewJsonBodyResponse("Hello, World!")
 
 	if response.Body != "Hello, World!" {
 		t.Errorf("Expected response.Body to be 'Hello, World!', but was '%s'", response.Body)


### PR DESCRIPTION
### Proposed changes

The meat, and the potatoes of the whole thing.

Accept an NGINX configuration on the `/nginx/config` endpoint; queue it up for processing; and return a HTTP Accepted status along with a Location for retrieving updates. 

The body will contain details of the request, including status, disposition, etc.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/ciroque-nginx/nginx-config-service/blob/main/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/ciroque-nginx/nginx-config-service/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/ciroque-nginx/nginx-config-service/blob/main/CHANGELOG.md))
